### PR TITLE
Added external_log_file to agent parameters.

### DIFF
--- a/scripts/mesos-agent-setup.ps1
+++ b/scripts/mesos-agent-setup.ps1
@@ -89,6 +89,7 @@ function New-MesosWindowsAgent {
                            " --runtime_dir=`"${MESOS_WORK_DIR}`"" + `
                            " --launcher_dir=`"${MESOS_BIN_DIR}`"" + `
                            " --log_dir=`"${MESOS_LOG_DIR}`"" + `
+                           " --external_log_file=`"${MESOS_LOG_DIR}\mesos-service.err.log`"" + `
                            " --ip=`"${agentAddress}`"" + `
                            " --isolation=`"windows/cpu,filesystem/windows`"" + `
                            " --containerizers=`"docker,mesos`"" + `


### PR DESCRIPTION
This adds the "--external_log_file" command line parameter to the invocation of mesos-agent. This will tell the agent where the agent logs are being written to, which thereby allows an HTTP API endpoint request like "/files/read?offset=0&length=100000&path=%2Fslave%2Flog" to access them.  The dcos CLI tool should be able to grab agent logs when run like this:

`dcos node log --follow --mesos-id=<NODE_ID>
`