### PR TITLE
Change dcos/dcos submodule to public HTTPs git URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "dcos"]
 	path = dcos
-	url = git@github.com:dcos/dcos.git
+	url = https://github.com/dcos/dcos.git


### PR DESCRIPTION
The URL given to the submodule [dcos/dcos](https://github.com/dcos/dcos) is the one used with the SSH key. However this causes issues when simply trying to clone recursively the repository [dcos/dcow-windows](https://github.com/dcos/dcos-windows) with the public HTTPs URLs.

Usage example: http://paste.openstack.org/show/m3yyrOvOcrNisp3Cq3aV

It makes more sense to simply have the public URL for the submodule as well, since that submodule repository is also public.