### PR TITLE
Added environment file for mesos agent service.

### DIFF
--- a/scripts/mesos-agent-setup.ps1
+++ b/scripts/mesos-agent-setup.ps1
@@ -99,10 +99,15 @@ function New-MesosWindowsAgent {
     if($Public) {
         $mesosAgentArguments += " --default_role=`"slave_public`""
     }
+    $environmentFile = Join-Path $MESOS_SERVICE_DIR "environment-file"
+    Set-Content -Path $environmentFile -Value @(
+        "MESOS_AUTHENTICATE_HTTP_READONLY=false",
+        "MESOS_AUTHENTICATE_HTTP_READWRITE=false"
+    )
     $wrapperPath = Join-Path $MESOS_SERVICE_DIR "service-wrapper.exe"
     Invoke-WebRequest -UseBasicParsing -Uri $SERVICE_WRAPPER_URL -OutFile $wrapperPath
     New-DCOSWindowsService -Name $MESOS_SERVICE_NAME -DisplayName $MESOS_SERVICE_DISPLAY_NAME -Description $MESOS_SERVICE_DESCRIPTION `
-                           -WrapperPath $wrapperPath -BinaryPath "$mesosBinary $mesosAgentArguments"
+                           -WrapperPath $wrapperPath -BinaryPath "$mesosBinary $mesosAgentArguments" -EnvironmentFiles @($environmentFile)
     Start-Service $MESOS_SERVICE_NAME
 }
 


### PR DESCRIPTION
This adds an environment file for the mesos agent service that is apparently sourced by the new service wrapper, in the same way that the spartan service sources its own environment file. Compare to lines 131-139 of spartan-agent-setup.ps1.

I've tested this and I've confirmed that these environment variables are set for the mesos-agent.exe process