### PR TITLE
Fix external_log_file functionality and explicitly set Mesos Windows slave hostname

### DIFF
--- a/scripts/mesos-agent-setup.ps1
+++ b/scripts/mesos-agent-setup.ps1
@@ -32,6 +32,7 @@ function New-MesosEnvironment {
     }
     New-Directory -RemoveExisting $MESOS_DIR
     New-Directory $MESOS_BIN_DIR
+    New-Directory $MESOS_LOG_DIR
     New-Directory $MESOS_WORK_DIR
     New-Directory $MESOS_SERVICE_DIR
 }
@@ -85,11 +86,13 @@ function New-MesosWindowsAgent {
     $mesosAttributes = Get-MesosAgentAttributes
     $masterZkAddress = "zk://" + ($MasterAddress -join ":2181,") + ":2181/mesos"
     $mesosPath = ($DOCKER_HOME -replace '\\', '\\') + ';' + ($MESOS_BIN_DIR -replace '\\', '\\')
+    $externalLogFile = Join-Path $MESOS_LOG_DIR "mesos-service.err.log"
+    New-Item -ItemType File -Path $externalLogFile
     $mesosAgentArguments = ("--master=`"${masterZkAddress}`"" + `
                            " --work_dir=`"${MESOS_WORK_DIR}`"" + `
                            " --runtime_dir=`"${MESOS_WORK_DIR}`"" + `
                            " --launcher_dir=`"${MESOS_BIN_DIR}`"" + `
-                           " --external_log_file=`"${MESOS_LOG_DIR}\mesos-service.err.log`"" + `
+                           " --external_log_file=`"${externalLogFile}`"" + `
                            " --log_dir=`"${MESOS_LOG_DIR}`"" + `
                            " --ip=`"${agentAddress}`"" + `
                            " --isolation=`"windows/cpu,filesystem/windows`"" + `

--- a/scripts/mesos-agent-setup.ps1
+++ b/scripts/mesos-agent-setup.ps1
@@ -98,6 +98,7 @@ function New-MesosWindowsAgent {
                            " --isolation=`"windows/cpu,filesystem/windows`"" + `
                            " --containerizers=`"docker,mesos`"" + `
                            " --attributes=`"${mesosAttributes}`"" + `
+                           " --hostname=`"${AgentPrivateIP}`"" +
                            " --executor_environment_variables=`"{\\\`"PATH\\\`": \\\`"${mesosPath}\\\`"}`"")
     if($Public) {
         $mesosAgentArguments += " --default_role=`"slave_public`""


### PR DESCRIPTION
This pull request introduces the following updates:

- File used for `--external_log_file` must exist. If the file doesn't exist, the following error is given:

```
Log file created at: 2018/01/16 10:37:02
Running on machine: 15580ACS000000
E0116 10:37:02.354581  1372 slave.cpp:1009] Failed to attach 'C:\DCOS\mesos\log\mesos-service.err.log' to virtual path '/slave/log': Failed to get realpath of 'C:\DCOS\mesos\log\mesos-service.err.log': Failed to get attributes for file 'C:\DCOS\mesos\log\mesos-service.err.log': The system cannot find the file specified.

```

- Set hostname explicitly for the Windows Mesos slave. If not set, the default hostname advertised to master nodes is the same one for all the Windows slaves:

```
$ dcos node
                             HOSTNAME                                     IP                          ID                    TYPE
22803acs000001.m1u5b2dryuhutcpk51iv1dm4pb.cx.internal.cloudapp.net     10.0.0.5    c9267e15-1e50-485d-a7ca-745bd8a87bf2-S0  agent
22803acs000001.m1u5b2dryuhutcpk51iv1dm4pb.cx.internal.cloudapp.net     10.1.0.5    c9267e15-1e50-485d-a7ca-745bd8a87bf2-S2  agent
                          master.mesos.                             192.168.255.5    e5b4afb5-42f1-46b0-9427-154da5490efa   master (leader)


$ nslookup 22803acs000001.m1u5b2dryuhutcpk51iv1dm4pb.cx.internal.cloudapp.net
Server:         198.51.100.1
Address:        198.51.100.1#53

Name:   22803acs000001.m1u5b2dryuhutcpk51iv1dm4pb.cx.internal.cloudapp.net
Address: 10.1.0.5
``` 

This is wrong and we now set the IP address as the hostname, just as it's happening with the Linux agents. 