### PR TITLE
Update Docker to latest CE and remove Spartan workarounds

### DIFF
--- a/scripts/DCOSWindowsAgentSetup.ps1
+++ b/scripts/DCOSWindowsAgentSetup.ps1
@@ -123,6 +123,16 @@ function Install-SpartanAgent {
     }
 }
 
+function Update-Docker {
+    $dockerHome = Join-Path $env:ProgramFiles "Docker"
+    $baseUrl = "http://dcos-win.westus.cloudapp.azure.com/downloads/docker"
+    $version = "18.02.0-ce"
+    Stop-Service "Docker"
+    Invoke-WebRequest -UseBasicParsing -Uri "${baseUrl}/${version}/docker.exe" -OutFile "${dockerHome}\docker.exe"
+    Invoke-WebRequest -UseBasicParsing -Uri "${baseUrl}/${version}/dockerd.exe" -OutFile "${dockerHome}\dockerd.exe"
+    Start-Service "Docker"
+}
+
 function New-DockerNATNetwork {
     #
     # This needs to be used by all the containers since DCOS Spartan DNS server
@@ -137,6 +147,7 @@ function New-DockerNATNetwork {
 }
 
 try {
+    Update-Docker
     New-DockerNATNetwork
     New-ScriptsDirectory
     Install-MesosAgent

--- a/scripts/DCOSWindowsAgentSetup.ps1
+++ b/scripts/DCOSWindowsAgentSetup.ps1
@@ -140,7 +140,7 @@ function New-DockerNATNetwork {
     # The Docker gateway address is added to the DNS server list unless
     # disable_gatewaydns network option is enabled.
     #
-    docker.exe network create --driver="nat" --opt "com.docker.network.windowsshim.disable_gatewaydns=true" "nat_network"
+    docker.exe network create --driver="nat" --opt "com.docker.network.windowsshim.disable_gatewaydns=true" "customnat"
     if($LASTEXITCODE -ne 0) {
         Throw "Failed to create the new Docker NAT network with disable_gatewaydns flag"
     }

--- a/scripts/Modules/Utils/Utils.psm1
+++ b/scripts/Modules/Utils/Utils.psm1
@@ -127,6 +127,8 @@ function New-DCOSWindowsService {
         [Parameter(Mandatory=$true)]
         [string]$BinaryPath,
         [Parameter(Mandatory=$false)]
+        [string]$LogFile,
+        [Parameter(Mandatory=$false)]
         [string[]]$EnvironmentFiles,
         [Parameter(Mandatory=$false)]
         [string]$PreStartCommand
@@ -150,6 +152,9 @@ function New-DCOSWindowsService {
     $binaryPathName = "`"$WrapperPath`" --service-name `"$Name`""
     if($PreStartCommand) {
         $binaryPathName += " --exec-start-pre `"$PreStartCommand`""
+    }
+    if($LogFile) {
+        $binaryPathName += " --log-file `"$LogFile`""
     }
     foreach($file in $EnvironmentFiles) {
         $binaryPathName += " --environment-file `"$file`""

--- a/scripts/epmd-agent-setup.ps1
+++ b/scripts/epmd-agent-setup.ps1
@@ -18,6 +18,7 @@ function New-Environment {
     }
     New-Directory -RemoveExisting $EPMD_DIR
     New-Directory $EPMD_SERVICE_DIR
+    New-Directory $EPMD_LOG_DIR
 }
 
 function New-EPMDWindowsAgent {
@@ -27,8 +28,9 @@ function New-EPMDWindowsAgent {
     }
     $wrapperPath = Join-Path $EPMD_SERVICE_DIR "service-wrapper.exe"
     Invoke-WebRequest -UseBasicParsing -Uri $SERVICE_WRAPPER_URL -OutFile $wrapperPath
+    $logFile = Join-Path $EPMD_LOG_DIR "epmd.log"
     New-DCOSWindowsService -Name $EPMD_SERVICE_NAME -DisplayName $EPMD_SERVICE_DISPLAY_NAME -Description $EPMD_SERVICE_DESCRIPTION `
-                           -WrapperPath $wrapperPath -BinaryPath "$epmdBinary -port $EPMD_PORT"
+                           -LogFile $logFile -WrapperPath $wrapperPath -BinaryPath "$epmdBinary -port $EPMD_PORT"
     Start-Service $EPMD_SERVICE_NAME
 }
 

--- a/scripts/mesos-agent-setup.ps1
+++ b/scripts/mesos-agent-setup.ps1
@@ -113,8 +113,9 @@ function New-MesosWindowsAgent {
     }
     $wrapperPath = Join-Path $MESOS_SERVICE_DIR "service-wrapper.exe"
     Invoke-WebRequest -UseBasicParsing -Uri $SERVICE_WRAPPER_URL -OutFile $wrapperPath
+    $logFile = Join-Path $MESOS_LOG_DIR "mesos-slave.log"
     New-DCOSWindowsService -Name $MESOS_SERVICE_NAME -DisplayName $MESOS_SERVICE_DISPLAY_NAME -Description $MESOS_SERVICE_DESCRIPTION `
-                           -WrapperPath $wrapperPath -BinaryPath "$mesosBinary $mesosAgentArguments" -EnvironmentFiles @($environmentFile)
+                           -LogFile $logFile -WrapperPath $wrapperPath -BinaryPath "$mesosBinary $mesosAgentArguments" -EnvironmentFiles @($environmentFile)
     Start-Service $MESOS_SERVICE_NAME
 }
 

--- a/scripts/templates/spartan/sys.spartan.config
+++ b/scripts/templates/spartan/sys.spartan.config
@@ -4,7 +4,8 @@
     {upstream_resolvers, {{ upstream_resolvers }}},
     {exhibitor_url, "{{ exhibitor_url }}"},
     {udp_port, 53},
-    {tcp_port, 53}
+    {tcp_port, 53},
+    {bind_ips, [{192, 51, 100, 1}, {192, 51, 100, 2}, {192, 51, 100, 3}]}
   ]},
   {erldns,[
     %% DB Config

--- a/scripts/variables.ps1
+++ b/scripts/variables.ps1
@@ -18,13 +18,6 @@ $MESOS_BIN_DIR = Join-Path $MESOS_DIR "bin"
 $MESOS_WORK_DIR = Join-Path $MESOS_DIR "work"
 $MESOS_LOG_DIR = Join-Path $MESOS_DIR "log"
 $MESOS_SERVICE_DIR = Join-Path $MESOS_DIR "service"
-$MESOS_BUILD_DIR = Join-Path $MESOS_DIR "build"
-$MESOS_BINARIES_DIR = Join-Path $MESOS_DIR "binaries"
-$MESOS_GIT_REPO_DIR = Join-Path $MESOS_DIR "mesos"
-$MESOS_BUILD_OUT_DIR = Join-Path $MESOS_DIR "build-output"
-$MESOS_BUILD_LOGS_DIR = Join-Path $MESOS_BUILD_OUT_DIR "logs"
-$MESOS_BUILD_BINARIES_DIR = Join-Path $MESOS_BUILD_OUT_DIR "binaries"
-$MESOS_BUILD_BASE_URL = "$LOG_SERVER_BASE_URL/mesos-build"
 
 # EPMD configurations
 $EPMD_SERVICE_NAME = "dcos-epmd"
@@ -32,6 +25,7 @@ $EPMD_SERVICE_DISPLAY_NAME = "DCOS EPMD Windows Agent"
 $EPMD_SERVICE_DESCRIPTION = "Windows Service for the DCOS EPMD Agent"
 $EPMD_PORT = 61420
 $EPMD_DIR = Join-Path $DCOS_DIR "epmd"
+$EPMD_LOG_DIR = Join-Path $EPMD_DIR "log"
 $EPMD_SERVICE_DIR = Join-Path $EPMD_DIR "service"
 
 # Spartan configurations
@@ -41,18 +35,11 @@ $SPARTAN_SERVICE_DISPLAY_NAME = "DCOS Spartan Windows Agent"
 $SPARTAN_SERVICE_DESCRIPTION = "Windows Service for the DCOS Spartan Windows Agent"
 $SPARTAN_DEVICE_NAME = "spartan"
 $SPARTAN_DIR = Join-Path $DCOS_DIR "spartan"
+$SPARTAN_LOG_DIR = Join-Path $SPARTAN_DIR "log"
 $SPARTAN_RELEASE_DIR = Join-Path $SPARTAN_DIR "release"
 $SPARTAN_SERVICE_DIR = Join-Path $SPARTAN_DIR "service"
-$SPARTAN_GIT_REPO_DIR = Join-Path $SPARTAN_DIR "spartan"
-$SPARTAN_BUILD_OUT_DIR = Join-Path $SPARTAN_DIR "build-output"
-$SPARTAN_BUILD_LOGS_DIR = Join-Path $SPARTAN_BUILD_OUT_DIR "logs"
-$SPARTAN_BUILD_BASE_URL = "$LOG_SERVER_BASE_URL/spartan-build"
 
 # Installers URLs
 $SERVICE_WRAPPER_URL = "$LOG_SERVER_BASE_URL/downloads/service-wrapper.exe"
 $VCREDIST_2013_URL = "https://download.microsoft.com/download/2/E/6/2E61CFA4-993B-4DD4-91DA-3737CD5CD6E3/vcredist_x64.exe"
 $DEVCON_CAB_URL = "https://download.microsoft.com/download/7/D/D/7DD48DE6-8BDA-47C0-854A-539A800FAA90/wdk/Installers/787bee96dbd26371076b37b13c405890.cab"
-
-# Git repositories URLs
-$MESOS_GIT_URL = "https://github.com/apache/mesos"
-$SPARTAN_GIT_URL = "https://github.com/dcos/spartan"

--- a/scripts/variables.ps1
+++ b/scripts/variables.ps1
@@ -35,6 +35,7 @@ $EPMD_DIR = Join-Path $DCOS_DIR "epmd"
 $EPMD_SERVICE_DIR = Join-Path $EPMD_DIR "service"
 
 # Spartan configurations
+$SPARTAN_LOCAL_ADDRESSES = @("192.51.100.1", "192.51.100.2", "192.51.100.3")
 $SPARTAN_SERVICE_NAME = "dcos-spartan"
 $SPARTAN_SERVICE_DISPLAY_NAME = "DCOS Spartan Windows Agent"
 $SPARTAN_SERVICE_DESCRIPTION = "Windows Service for the DCOS Spartan Windows Agent"


### PR DESCRIPTION
This pull request adds the following updates:

- Rename custom NAT network from `nat_network` to `customnat`
- Add logic to update Docker to the latest CE version in order to have https://github.com/docker/libnetwork/commit/884eaa0157709a3197b9696981c4f1ce0d86120b commit in the build. This will allow us to remove all the Spartan workarounds to get it working.
- Remove Spartan workarounds around the broken Docker version
- Add `LogFile` to the `New-DCOSWindowsService` utils function
- Add logging to file to all the wrapped DCOS services