### PR TITLE
Make all DC/OS agents share a single service wrapper

### DIFF
--- a/scripts/DCOSWindowsAgentSetup.ps1
+++ b/scripts/DCOSWindowsAgentSetup.ps1
@@ -208,12 +208,22 @@ function New-DCOSEnvironmentFile {
     )
 }
 
+function New-DCOSServiceWrapper {
+    . "$SCRIPTS_DIR\scripts\variables.ps1"
+    $parent = Split-Path -Parent -Path $SERVICE_WRAPPER
+    if(!(Test-Path -Path $parent)) {
+        New-Item -ItemType "Directory" -Path $parent
+    }
+    Start-ExecuteWithRetry { Invoke-WebRequest -UseBasicParsing -Uri $SERVICE_WRAPPER_URL -OutFile $SERVICE_WRAPPER }
+}
+
 
 try {
     New-ScriptsDirectory
     Update-Docker
     New-DockerNATNetwork
     New-DCOSEnvironmentFile
+    New-DCOSServiceWrapper
     Install-MesosAgent
     Install-ErlangRuntime
     Install-EPMDAgent

--- a/scripts/DCOSWindowsAgentSetup.ps1
+++ b/scripts/DCOSWindowsAgentSetup.ps1
@@ -200,6 +200,7 @@ function New-DCOSEnvironmentFile {
         New-Item -ItemType "Directory" -Path $DCOS_DIR
     }
     $envFile = Join-Path $DCOS_DIR "environment"
+    $masterIPs = Get-MasterIPs
     Write-Output "Trying to find the DC/OS version by querying the API of the masters: $($masterIPs -join ', ')"
     $dcosVersion = Get-DCOSVersion
     Set-Content -Path $envFile -Value @(

--- a/scripts/epmd-agent-setup.ps1
+++ b/scripts/epmd-agent-setup.ps1
@@ -26,11 +26,9 @@ function New-EPMDWindowsAgent {
     if(!(Test-Path $epmdBinary)) {
         Throw "The EPMD binary $epmdBinary doesn't exist. Cannot configure the EPMD agent Windows service"
     }
-    $wrapperPath = Join-Path $EPMD_SERVICE_DIR "service-wrapper.exe"
-    Start-ExecuteWithRetry { Invoke-WebRequest -UseBasicParsing -Uri $SERVICE_WRAPPER_URL -OutFile $wrapperPath }
     $logFile = Join-Path $EPMD_LOG_DIR "epmd.log"
     New-DCOSWindowsService -Name $EPMD_SERVICE_NAME -DisplayName $EPMD_SERVICE_DISPLAY_NAME -Description $EPMD_SERVICE_DESCRIPTION `
-                           -LogFile $logFile -WrapperPath $wrapperPath -BinaryPath "$epmdBinary -port $EPMD_PORT"
+                           -LogFile $logFile -WrapperPath $SERVICE_WRAPPER -BinaryPath "$epmdBinary -port $EPMD_PORT"
     Start-Service $EPMD_SERVICE_NAME
 }
 

--- a/scripts/mesos-agent-setup.ps1
+++ b/scripts/mesos-agent-setup.ps1
@@ -110,10 +110,8 @@ function New-MesosWindowsAgent {
           "MESOS_AUTHENTICATE_HTTP_READWRITE=false"
       )
     }
-    $wrapperPath = Join-Path $MESOS_SERVICE_DIR "service-wrapper.exe"
-    Start-ExecuteWithRetry { Invoke-WebRequest -UseBasicParsing -Uri $SERVICE_WRAPPER_URL -OutFile $wrapperPath }
     New-DCOSWindowsService -Name $MESOS_SERVICE_NAME -DisplayName $MESOS_SERVICE_DISPLAY_NAME -Description $MESOS_SERVICE_DESCRIPTION `
-                           -LogFile $logFile -WrapperPath $wrapperPath -BinaryPath "$mesosBinary $mesosAgentArguments" -EnvironmentFiles @($environmentFile)
+                           -LogFile $logFile -WrapperPath $SERVICE_WRAPPER -BinaryPath "$mesosBinary $mesosAgentArguments" -EnvironmentFiles @($environmentFile)
     Start-Service $MESOS_SERVICE_NAME
 }
 

--- a/scripts/spartan-agent-setup.ps1
+++ b/scripts/spartan-agent-setup.ps1
@@ -137,11 +137,9 @@ function New-SpartanWindowsAgent {
         "MASTER_SOURCE=master_list",
         "MASTER_LIST_FILE=${mastersListFile}"
     )
-    $wrapperPath = Join-Path $SPARTAN_SERVICE_DIR "service-wrapper.exe"
-    Start-ExecuteWithRetry { Invoke-WebRequest -UseBasicParsing -Uri $SERVICE_WRAPPER_URL -OutFile $wrapperPath }
     $logFile = Join-Path $SPARTAN_LOG_DIR "spartan.log"
     New-DCOSWindowsService -Name $SPARTAN_SERVICE_NAME -DisplayName $SPARTAN_SERVICE_DISPLAY_NAME -Description $SPARTAN_SERVICE_DESCRIPTION `
-                           -LogFile $logFile -WrapperPath $wrapperPath -EnvironmentFiles @($environmentFile) -BinaryPath "`"$erlBinary $spartanArguments`""
+                           -LogFile $logFile -WrapperPath $SERVICE_WRAPPER -EnvironmentFiles @($environmentFile) -BinaryPath "`"$erlBinary $spartanArguments`""
     Start-Service $SPARTAN_SERVICE_NAME
     Set-DnsClientServerAddress -InterfaceAlias * -ServerAddresses $SPARTAN_LOCAL_ADDRESSES
 }

--- a/scripts/variables.ps1
+++ b/scripts/variables.ps1
@@ -7,6 +7,7 @@ $DCOS_DIR = Join-Path $env:SystemDrive "DCOS"
 $ERLANG_DIR = Join-Path $DCOS_DIR "erl8.3"
 $ERTS_DIR = Join-Path $ERLANG_DIR "erts-8.3"
 $DOCKER_HOME = Join-Path $env:ProgramFiles "Docker"
+$SERVICE_WRAPPER = Join-Path $DCOS_DIR "service-wrapper.exe"
 
 # Mesos configurations
 $MESOS_SERVICE_NAME = "dcos-mesos-slave"


### PR DESCRIPTION
This pull request makes all the current DC/OS agents on Windows (`mesos`, `spartan` and `epmd`) to share a single service wrapper binary located at: `C:\DCOS\service-wrapper.exe`