### PR TITLE
Fix `Get-MasterIPs` function

### DIFF
--- a/scripts/DCOSWindowsAgentSetup.ps1
+++ b/scripts/DCOSWindowsAgentSetup.ps1
@@ -122,7 +122,7 @@ function Get-MasterIPs {
     [string[]]$ips = ConvertFrom-Json $MasterIP
     # NOTE(ibalutoiu): ACS-Engine adds the Zookeper port to every master IP and we need only the address
     [string[]]$masterIPs = $ips | ForEach-Object { $_.Split(':')[0] }
-    return $masterIPs
+    return ,$masterIPs
 }
 
 function Install-MesosAgent {


### PR DESCRIPTION
Fix `Get-MasterIPs` function

If you return an array with a single item from a function in
PowerShell, the language will automatically unpack the array
and return the item instead.

We need `Get-MasterIPs` function to always return a list of IPs.