### PR TITLE
Removed dcos-metrics server from diagnostics checking list

### DIFF
--- a/scripts/DCOSWindowsAgentSetup.ps1
+++ b/scripts/DCOSWindowsAgentSetup.ps1
@@ -28,6 +28,7 @@ $MESOS_BINARIES_URL = "$BootstrapUrl/mesos.zip"
 $DIAGNOSTICS_BINARIES_URL = "$BootstrapUrl/diagnostics.zip"
 $DCOS_NET_ZIP_PACKAGE_URL = "$BootstrapUrl/dcos-net.zip"
 $METRICS_BINARIES_URL = "$BootstrapUrl/metrics.zip"
+$ADMINROUTER_BINARIES_URL = "$BootstrapUrl/adminrouter.zip"
 
 function Add-ToSystemPath {
     Param(
@@ -157,7 +158,7 @@ function Install-SpartanAgent {
 }
 
 function Install-AdminRouterAgent {
-    & "$SCRIPTS_DIR\scripts\adminrouter-agent-setup.ps1" -AgentPrivateIP $AgentPrivateIP
+    & "$SCRIPTS_DIR\scripts\adminrouter-agent-setup.ps1" -AgentPrivateIP $AgentPrivateIP -AdminRouterWindowsBinariesURL $ADMINROUTER_BINARIES_URL
     if($LASTEXITCODE) {
         Throw "Failed to setup the DCOS AdminRouter Windows agent"
     }

--- a/scripts/adminrouter-agent-setup.ps1
+++ b/scripts/adminrouter-agent-setup.ps1
@@ -1,11 +1,12 @@
 #======================================================================================
 # This script sets up the AdminRouter agent on a Windows node
-# This AdminRouter consists IIS, Application Request Routing and URL Rewrite with a 
-# set of a url rewrite rules
+# This AdminRouter was implemented on top of the Apache HTTP server + config with 
+# reverse proxy settings
 #======================================================================================
 Param(
     [Parameter(Mandatory=$true)]
-    [string]$AgentPrivateIP
+    [string]$AgentPrivateIP,
+    [string]$AdminRouterWindowsBinariesURL
 )
 
 $utils = (Resolve-Path "$PSScriptRoot\Modules\Utils").Path
@@ -14,142 +15,54 @@ Import-Module $utils
 $variables = (Resolve-Path "$PSScriptRoot\variables.ps1").Path
 . $variables
 
-Function Install-AdminModule{
-  Param(
-        [Parameter(Mandatory=$true)][string]$Name,
-        [Parameter(Mandatory=$true)][string]$MSISourceUri,
-        [Parameter(Mandatory=$true)][string]$DownloadDestFile,
-        [Parameter(Mandatory=$true)][string]$Logfile
-        )
-
-    Write-Output "Download and install $Name module"
-    Start-ExecuteWithRetry { Invoke-WebRequest -Uri $MSISourceUri -OutFile $DownloadDestFile }
-
-    $MSIArguments = @(
-        "/i"
-        ('"{0}"' -f $DownloadDestFile)
-        "/qn"
-        "/norestart"
-        "/L*v"
-        $Logfile
-    )
-    $p = Start-Process "msiexec.exe" -ArgumentList $MSIArguments -Wait -PassThru -NoNewWindow
-
-    if($p.ExitCode -ne 0) {
-        Throw "ERROR: Could not install $Name module"
-    }
-}
-
-Function Install-URLRewriteAndARRModules{
-    $downloadDir = Join-Path $env:TEMP "dcos-download/"
-    # URL Rewrite
-    $UrlRewrite = "IIS URL Rewrite Module 2"
-    $UrlRewritelogfile = "rewrite.log"
-    [string] $URLRewrite_Plugin_File = $downloadDir + "rewrite_amd64_en-US.msi"
-
-    # Application Request Routing: AAR
-    $ARR = "Microsoft Application Request Routing 3.0"
-    $ARRlogfile = "apprequestrouting.log"
-    [string] $ARR_Plugin_File = $downloadDir + "requestRouter_amd64.msi"
-	New-Item -Path $downloadDir -ItemType directory -Force
-    Install-AdminModule -Name $UrlRewrite -MSISourceUri $URL_REWRITE_MODULE_URL -DownloadDestFile $URLRewrite_Plugin_File -Logfile $ARRlogfile 
-    Install-AdminModule -Name $ARR -MSISourceUri $ARR_MODULE_URL -DownloadDestFile $ARR_Plugin_File -Logfile $UrlRewritelogfile
-}
-
-function Install-IISAndTools{
-    $RequiredComponents = @("Web-Server","Web-Mgmt-Tools","Web-Request-Monitor", "Web-Http-Tracing")
-    foreach ($component in $RequiredComponents) {
-        $feature = Get-WindowsFeature -Name $component
-        if ($feature.InstallState -Eq "Installed"){
-            Write-Output " 	$component was already installed"
-        } else {
-            Install-WindowsFeature $component
+function New-AdminRouterEnvironment {
+    $service = Get-Service $ADMINROUTER_SERVICE_NAME -ErrorAction SilentlyContinue
+    if($service) {
+        Stop-Service -Force -Name $ADMINROUTER_SERVICE_NAME
+        & sc.exe delete $ADMINROUTER_SERVICE_NAME
+        if($LASTEXITCODE) {
+            Throw "Failed to delete exiting $ADMINROUTER_SERVICE_NAME service"
         }
+        Write-Output "Deleted existing $ADMINROUTER_SERVICE_NAME service"
     }
+    New-Directory -RemoveExisting $ADMINROUTER_DIR
+    New-Directory $ADMINROUTER_LOG_DIR
 }
 
-function Open-AdminRouterPort {
-    $AdminRouterPort = 61001
-    Open-WindowsFirewallRule -Name "Allow inbound TCP Port $AdminRouterPort for AdminRouter" -Direction "Inbound" -LocalPort $AdminRouterPort -Protocol "TCP"
+function Install-AdminRouterFiles {
+    $filesPath = Join-Path $env:TEMP "adminrouter-files.zip"
+    Write-Output "Downloading AdminRouter binaries"
+    Start-ExecuteWithRetry { Invoke-WebRequest -Uri $AdminRouterWindowsBinariesURL -OutFile $filesPath }
+    Write-Output "Extracting binaries archive in: $ADMINROUTER_DIR"
+    Expand-Archive -LiteralPath $filesPath -DestinationPath $ADMINROUTER_DIR
+    Add-ToSystemPath $ADMINROUTER_DIR
+    Remove-item $filesPath
 }
 
-function Setup-AdminRouter(
-           [string[]]$MasterAddress,
-           [string]$AgentPrivateIP) {
+function New-AdminRouterAgent {
+   $logFile = Join-Path $ADMINROUTER_LOG_DIR "adminrouter-agent.log"
+    New-Item -ItemType File -Path $logFile
+    $adminrouterBinary = Join-Path $ADMINROUTER_APACHE_BIN_DIR "httpd.exe"
+ 
+    # open up adminrouter port
+    Open-WindowsFirewallRule -Name "Allow inbound TCP Port $ADMINROUTER_AGENT_PORT for AdminRouter" -Direction "Inbound" -LocalPort $ADMINROUTER_AGENT_PORT -Protocol "TCP"
 
-    #  Install IIS and tools
-    Install-IISAndTools
-    import-module WebAdministration
+    # start Apache server
+    $configFile = Join-Path $ADMINROUTER_APACHE_CONF_DIR "adminrouter.conf"
+    $adminrouterAgentArguments = (  "-f `"${configFile}`" " )
 
-    # Remove default IIS website listening on port 80
-    Get-Website 'Default Web Site' | Remove-Website -Confirm:$false
-
-    #  Install URL Rewrite and Application Request Routing modules
-    Install-URLRewriteAndARRModules
-
-    # Setup the adminrouter server      
-    Write-Output "Setting up the AdminRouter server"
-    $adminRouterPath="IIS:\AppPools\AdminRouter"
-    $existed = Test-Path -Path $adminRouterPath
-    if (! $existed -eq $True) {
-        Write-Output "creating IIS:\AppPools\AdminRouter"
-        $adminappgroup = new-item "IIS:\AppPools\AdminRouter" -Force
-    }
-
-    Write-Output "Setting up new website at $agentPrivateIP with $env:SystemDrive:\inetpub\wwwroot\DCOS as root directory"
-    $adminrouter_dir = new-item -ItemType "Directory" "$env:SystemDrive:\inetpub\wwwroot\DCOS" -force
-    New-Website -Name "adminrouter" -Port 61001 -IPAddress $agentPrivateIP -PhysicalPath $adminrouter_dir -ApplicationPool "AdminRouter" -Force
+    New-DCOSWindowsService -Name $ADMINROUTER_SERVICE_NAME -DisplayName $ADMINROUTER_SERVICE_DISPLAY_NAME -Description $ADMINROUTER_SERVICE_DESCRIPTION `
+                           -LogFile $logFile -WrapperPath $SERVICE_WRAPPER -BinaryPath "$adminrouterBinary $adminrouterAgentArguments"
+    Start-Service $ADMINROUTER_SERVICE_NAME
 }
-
-function Add-Routes{
-    # enable proxy
-    Write-Output "Enabling proxy on Application Request Routing"
-    Set-WebConfigurationProperty -pspath 'MACHINE/WEBROOT/APPHOST'  -filter "system.webServer/proxy" -name "enabled" -value "True"
-
-    # setup url rewrite rule for DC/OS Diagnostics service
-    Write-Output "setup url rewrite rule for DC/OS Diagnostics service"
-    Add-WebConfigurationProperty -pspath 'MACHINE/WEBROOT/APPHOST'  -filter "system.webServer/rewrite/rules" -name "." -value @{name='Reverse Proxy for the DC/OS Diagnostics agent service';stopProcessing='True'}
-    Set-WebConfigurationProperty -pspath 'MACHINE/WEBROOT/APPHOST'  -filter "system.webServer/rewrite/rules/rule[@name='Reverse Proxy for the DC/OS Diagnostics agent service']/match" -name "url" -value "^system/health/v1(.*)"
-    Set-WebConfigurationProperty -pspath 'MACHINE/WEBROOT/APPHOST'  -filter "system.webServer/rewrite/rules/rule[@name='Reverse Proxy for the DC/OS Diagnostics agent service']/action" -name "type" -value "Rewrite"
-    Set-WebConfigurationProperty -pspath 'MACHINE/WEBROOT/APPHOST'  -filter "system.webServer/rewrite/rules/rule[@name='Reverse Proxy for the DC/OS Diagnostics agent service']/action" -name "url" -value "http://localhost:$DIAGNOSTICS_AGENT_PORT/{R:0}"
-
-    Write-Output "setup url rewrite rule for DC/OS Metrics service"
-    Add-WebConfigurationProperty -pspath 'MACHINE/WEBROOT/APPHOST'  -filter "system.webServer/rewrite/rules" -name "." -value @{name='Reverse Proxy for the DC/OS Metrics agent service';stopProcessing='True'}
-    Set-WebConfigurationProperty -pspath 'MACHINE/WEBROOT/APPHOST'  -filter "system.webServer/rewrite/rules/rule[@name='Reverse Proxy for the DC/OS Metrics agent service']/match" -name "url" -value "^system/v1/metrics/(.*)"
-    Set-WebConfigurationProperty -pspath 'MACHINE/WEBROOT/APPHOST'  -filter "system.webServer/rewrite/rules/rule[@name='Reverse Proxy for the DC/OS Metrics agent service']/action" -name "type" -value "Rewrite"
-    Set-WebConfigurationProperty -pspath 'MACHINE/WEBROOT/APPHOST'  -filter "system.webServer/rewrite/rules/rule[@name='Reverse Proxy for the DC/OS Metrics agent service']/action" -name "url" -value "http://localhost:$METRICS_AGENT_PORT/{R:1}"
-
-
-    # setup up outbound rules
-    Add-WebConfigurationProperty -pspath 'MACHINE/WEBROOT/APPHOST/adminrouter'  -filter "system.webServer/rewrite/outboundRules/preConditions" -name "." -value @{name='IsHTML';logicalGrouping='MatchAll'}
-    Add-WebConfigurationProperty -pspath 'MACHINE/WEBROOT/APPHOST/adminrouter'  -filter "system.webServer/rewrite/outboundRules/preConditions/preCondition[@name='IsHTML']" -name "." -value @{input='{RESPONSE_CONTENT_TYPE}';pattern='^text/html'}
-    Add-WebConfigurationProperty -pspath 'MACHINE/WEBROOT/APPHOST/adminrouter'  -filter "system.webServer/rewrite/outboundRules/preConditions" -name "." -value @{name='IsRedirection'}
-    Add-WebConfigurationProperty -pspath 'MACHINE/WEBROOT/APPHOST/adminrouter'  -filter "system.webServer/rewrite/outboundRules/preConditions/preCondition[@name='IsRedirection']" -name "." -value @{input='{RESPONSE_STATUS}';pattern='3\d\d'}
-    Add-WebConfigurationProperty -pspath 'MACHINE/WEBROOT/APPHOST/adminrouter'  -filter "system.webServer/rewrite/outboundRules" -name "." -value @{name='outbound rewrite';preCondition='IsHTML'}
-    Set-WebConfigurationProperty -pspath 'MACHINE/WEBROOT/APPHOST/adminrouter'  -filter "system.webServer/rewrite/outboundRules/rule[@name='outbound rewrite']/match" -name "filterByTags" -value "A"
-    Set-WebConfigurationProperty -pspath 'MACHINE/WEBROOT/APPHOST/adminrouter'  -filter "system.webServer/rewrite/outboundRules/rule[@name='outbound rewrite']/match" -name "pattern" -value "^(.*)"
-    Add-WebConfigurationProperty -pspath 'MACHINE/WEBROOT/APPHOST/adminrouter'  -filter "system.webServer/rewrite/outboundRules/rule[@name='outbound rewrite']/conditions" -name "." -value @{input='{URL}';pattern='^/(system/health/v1|system/v1/metrics)/.\*'}
-    Set-WebConfigurationProperty -pspath 'MACHINE/WEBROOT/APPHOST/adminrouter'  -filter "system.webServer/rewrite/outboundRules/rule[@name='outbound rewrite']/action" -name "type" -value "Rewrite"
-    Set-WebConfigurationProperty -pspath 'MACHINE/WEBROOT/APPHOST/adminrouter'  -filter "system.webServer/rewrite/outboundRules/rule[@name='outbound rewrite']/action" -name "value" -value "/{C:1}/{R:1}"
-    Add-WebConfigurationProperty -pspath 'MACHINE/WEBROOT/APPHOST/adminrouter'  -filter "system.webServer/rewrite/outboundRules" -name "." -value @{name='Rewrite location header';preCondition='IsRedirection'}
-    Set-WebConfigurationProperty -pspath 'MACHINE/WEBROOT/APPHOST/adminrouter'  -filter "system.webServer/rewrite/outboundRules/rule[@name='Rewrite location header']/match" -name "serverVariable" -value "RESPONSE_Location"
-    Set-WebConfigurationProperty -pspath 'MACHINE/WEBROOT/APPHOST/adminrouter'  -filter "system.webServer/rewrite/outboundRules/rule[@name='Rewrite location header']/match" -name "pattern" -value "http://[^/]+/(.*)"
-    Add-WebConfigurationProperty -pspath 'MACHINE/WEBROOT/APPHOST/adminrouter'  -filter "system.webServer/rewrite/outboundRules/rule[@name='Rewrite location header']/conditions" -name "." -value @{input='{ORIGINAL_HOST}';pattern='.+'}
-    Add-WebConfigurationProperty -pspath 'MACHINE/WEBROOT/APPHOST/adminrouter'  -filter "system.webServer/rewrite/outboundRules/rule[@name='Rewrite location header']/conditions" -name "." -value @{input='{URL}';pattern='^(system/health/v1|system/v1/metrics)/.\*'}
-    Set-WebConfigurationProperty -pspath 'MACHINE/WEBROOT/APPHOST/adminrouter'  -filter "system.webServer/rewrite/outboundRules/rule[@name='Rewrite location header']/action" -name "type" -value "Rewrite"
-    Set-WebConfigurationProperty -pspath 'MACHINE/WEBROOT/APPHOST/adminrouter'  -filter "system.webServer/rewrite/outboundRules/rule[@name='Rewrite location header']/action" -name "value" -value "http://{ORIGINAL_URL}/{C:1}/{R:1}"
-}
-
 
 try {
-    Write-Output "Setting up AdminRouter"
-    Open-AdminRouterPort
-    Setup-AdminRouter -AgentPrivateIP $AgentPrivateIP
-    Add-Routes
+    New-AdminRouterEnvironment
+    Install-AdminRouterFiles
+    New-AdminRouterAgent
 } catch {
     Write-Output $_.ToString()
-    exit 1 
+    exit 1
 }
-    
-Write-Output "Successfully finished setting up the AdminRouter"
+Write-Output "Successfully finished setting up the Windows AdminRouter Service Agent"
 exit 0

--- a/scripts/diagnostics-agent-setup.ps1
+++ b/scripts/diagnostics-agent-setup.ps1
@@ -1,6 +1,7 @@
 Param(
     [Parameter(Mandatory=$true)]
-    [string]$DiagnosticsWindowsBinariesURL
+    [string]$DiagnosticsWindowsBinariesURL,
+    [bool]$IncludeMetrics
 )
 
 $ErrorActionPreference = "Stop"
@@ -49,7 +50,14 @@ function Get-DCOSVersionFromFile {
 }
 
 function Get-MonitoredServices {
-    $services = @('dcos-diagnostics', 'dcos-mesos-slave', 'dcos-adminrouter')
+    Param(
+        [bool]$IncludeMetricsService
+    )
+    [System.Collections.ArrayList]$services = @('dcos-diagnostics', 'dcos-mesos-slave')
+    if ($IncludeMetricsService) {
+        $services.Add("dcos-adminrouter")
+    } 
+
     $dcosVersion = Get-DCOSVersionFromFile
     if($dcosVersion.StartsWith("1.8") -or $dcosVersion.StartsWith("1.9") -or $dcosVersion.StartsWith("1.10")) {
         $services += @('dcos-epmd', 'dcos-spartan')
@@ -61,6 +69,9 @@ function Get-MonitoredServices {
 }
 
 function New-DiagnosticsAgent {
+    Param(
+        [bool]$NeedToMonitorMetricsService
+    )   
     $diagnosticsBinary = Join-Path $DIAGNOSTICS_DIR "dcos-diagnostics.exe"
     $logFile = Join-Path $DIAGNOSTICS_LOG_DIR "diagnostics-agent.log"
     New-Item -ItemType File -Path $logFile
@@ -71,7 +82,7 @@ function New-DiagnosticsAgent {
                                     "--no-unix-socket " + `
                                     "--port `"${DIAGNOSTICS_AGENT_PORT}`" " + `
                                     "--endpoint-config `"${dcos_endpoint_config_dir}`"")
-    Get-MonitoredServices | Out-File -Encoding ascii -FilePath "${DIAGNOSTICS_DIR}\servicelist.txt"
+    Get-MonitoredServices -IncludeMetricsService $NeedToMonitorMetricsService | Out-File -Encoding ascii -FilePath "${DIAGNOSTICS_DIR}\servicelist.txt"
     $environmentFile = Join-Path $DCOS_DIR "environment"
     New-DCOSWindowsService -Name $DIAGNOSTICS_SERVICE_NAME -DisplayName $DIAGNOSTICS_SERVICE_DISPLAY_NAME -Description $DIAGNOSTICS_SERVICE_DESCRIPTION `
                            -LogFile $logFile -WrapperPath $SERVICE_WRAPPER -BinaryPath "$diagnosticsBinary $diagnosticsAgentArguments" -EnvironmentFiles @($environmentFile)
@@ -81,7 +92,7 @@ function New-DiagnosticsAgent {
 try {
     New-DiagnosticsEnvironment
     Install-DiagnosticsFiles
-    New-DiagnosticsAgent
+    New-DiagnosticsAgent -NeedToMonitorMetricsService $IncludeMetrics
 } catch {
     Write-Output $_.ToString()
     exit 1

--- a/scripts/diagnostics-agent-setup.ps1
+++ b/scripts/diagnostics-agent-setup.ps1
@@ -22,9 +22,7 @@ function New-DiagnosticsEnvironment {
         Write-Output "Deleted existing $DIAGNOSTICS_SERVICE_NAME service"
     }
     New-Directory -RemoveExisting $DIAGNOSTICS_DIR
-    New-Directory $DIAGNOSTICS_BIN_DIR
     New-Directory $DIAGNOSTICS_LOG_DIR
-    New-Directory $DIAGNOSTICS_SERVICE_DIR
     New-Directory $DIAGNOSTICS_CONFIG_DIR
 }
 
@@ -51,7 +49,7 @@ function Get-DCOSVersionFromFile {
 }
 
 function Get-MonitoredServices {
-    $services = @('dcos-diagnostics', 'dcos-mesos-slave', 'dcos-metrics')
+    $services = @('dcos-diagnostics', 'dcos-mesos-slave', 'dcos-adminrouter')
     $dcosVersion = Get-DCOSVersionFromFile
     if($dcosVersion.StartsWith("1.8") -or $dcosVersion.StartsWith("1.9") -or $dcosVersion.StartsWith("1.10")) {
         $services += @('dcos-epmd', 'dcos-spartan')

--- a/scripts/variables.ps1
+++ b/scripts/variables.ps1
@@ -49,9 +49,7 @@ $DIAGNOSTICS_SERVICE_DESCRIPTION = "Windows Service for the DCOS Diagnostics age
 $DIAGNOSTICS_AGENT_PORT = 9003
 $DIAGNOSTICS_DIR = Join-Path $DCOS_DIR "diagnostics"
 $DIAGNOSTICS_CONFIG_DIR = Join-Path $DIAGNOSTICS_DIR "config"
-$DIAGNOSTICS_BIN_DIR = Join-Path $DIAGNOSTICS_DIR "bin"
 $DIAGNOSTICS_LOG_DIR = Join-Path $DIAGNOSTICS_DIR "log"
-$DIAGNOSTICS_SERVICE_DIR = Join-Path $DIAGNOSTICS_DIR "service"
 
 # dcos-net configurations
 $DCOS_NET_LOCAL_ADDRESSES = @("192.51.100.1", "192.51.100.2", "192.51.100.3")
@@ -75,10 +73,19 @@ $METRICS_BIN_DIR = Join-Path $METRICS_DIR "bin"
 $METRICS_LOG_DIR = Join-Path $METRICS_DIR "log"
 $METRICS_SERVICE_DIR = Join-Path $METRICS_DIR "service"
 
+# AdminRouter configurations
+$ADMINROUTER_SERVICE_NAME = "dcos-adminrouter"
+$ADMINROUTER_SERVICE_DISPLAY_NAME = "DCOS AdminRouter Windows agent"
+$ADMINROUTER_SERVICE_DESCRIPTION = "Windows Service for the DCOS AdminRouter agent"
+$ADMINROUTER_AGENT_PORT = 61001
+$ADMINROUTER_DIR = Join-Path $DCOS_DIR "adminrouter"
+$ADMINROUTER_LOG_DIR = Join-Path $ADMINROUTER_DIR "log"
+$ADMINROUTER_APACHE_DIR = Join-Path $ADMINROUTER_DIR "Apache24"
+$ADMINROUTER_APACHE_CONF_DIR = Join-Path $ADMINROUTER_APACHE_DIR "conf"
+$ADMINROUTER_APACHE_BIN_DIR = Join-Path $ADMINROUTER_APACHE_DIR "bin"
+
 # Installers URLs
 $SERVICE_WRAPPER_URL = "$LOG_SERVER_BASE_URL/downloads/service-wrapper.exe"
 $VCREDIST_2013_URL = "https://download.microsoft.com/download/2/E/6/2E61CFA4-993B-4DD4-91DA-3737CD5CD6E3/vcredist_x64.exe"
 $VCREDIST_2017_URL = "https://download.visualstudio.microsoft.com/download/pr/11687625/2cd2dba5748dc95950a5c42c2d2d78e4/VC_redist.x64.exe"
 $DEVCON_CAB_URL = "https://download.microsoft.com/download/7/D/D/7DD48DE6-8BDA-47C0-854A-539A800FAA90/wdk/Installers/787bee96dbd26371076b37b13c405890.cab"
-$URL_REWRITE_MODULE_URL = 'http://download.microsoft.com/download/D/D/E/DDE57C26-C62C-4C59-A1BB-31D58B36ADA2/rewrite_amd64_en-US.msi'
-$ARR_MODULE_URL = "https://download.microsoft.com/download/E/9/8/E9849D6A-020E-47E4-9FD0-A023E99B54EB/requestRouter_amd64.msi"


### PR DESCRIPTION
This PR removes dcos-metrics from the list of services that diagnostics monitors for avoid a node unhealthy issue caused by the missing of metrics service when authentication was added.
