### PR TITLE
Fix regression with diagnostics agent setup

### DIFF
--- a/scripts/DCOSWindowsAgentSetup.ps1
+++ b/scripts/DCOSWindowsAgentSetup.ps1
@@ -167,7 +167,7 @@ function Install-DiagnosticsAgent {
     Param(
         [bool]$IncludeMatricsService
     )
-    & "$SCRIPTS_DIR\scripts\diagnostics-agent-setup.ps1" -IncludeMetricsToMonitoredSericeList $IncludeMatricsService
+    & "$SCRIPTS_DIR\scripts\diagnostics-agent-setup.ps1" -DiagnosticsWindowsBinariesURL $DIAGNOSTICS_BINARIES_URL -IncludeMetricsToMonitoredSericeList $IncludeMatricsService
     if($LASTEXITCODE) {
         Throw "Failed to setup the DCOS Diagnostics Windows agent"
     }


### PR DESCRIPTION
DC/OS Diagnostics couldn't be properly set up after PR https://github.com/dcos/dcos-windows/pull/36 was merged.

Without this fix, the provisioning VM extension for the Windows VMs will always time out.

The cause for this is the fact that `-DiagnosticsWindowsBinariesURL $DIAGNOSTICS_BINARIES_URL` was removed [here](https://github.com/dcos/dcos-windows/pull/36/commits/fe0f53440921d5ff2158804c131a477607b2d3f6#diff-410134c80a3af7080cc11bcacbe3688dL167).