### PR TITLE
Change the default service behaviour creation

### DIFF
--- a/scripts/Modules/Utils/Utils.psm1
+++ b/scripts/Modules/Utils/Utils.psm1
@@ -162,7 +162,7 @@ function New-DCOSWindowsService {
     $binaryPathName += " $BinaryPath"
     $params['BinaryPathName'] = $binaryPathName
     New-Service @params | Out-Null
-    Start-ExternalCommand { sc.exe failure $Name reset=5 actions=restart/1000 }
+    Start-ExternalCommand { sc.exe failure $Name reset=40 actions=restart/0/restart/0/restart/30000}
     Start-ExternalCommand { sc.exe failureflag $Name 1 }
 }
 


### PR DESCRIPTION
Until now we restarted the service every time it did not gracefully stopped,
with 1 second delay between restarts.

This patch proposes a new default behaviour.

The first two restart come instantly while for the third restart we add a 30
second timeout.

We reset the flags above if and only if the service was running for more than
40 seconds.

I.E.:
In the case a service is broken now it will have the following behaviour
from the point of view of SCM:
```(start *)``` - restart (0 ms) - restart (0 ms) - restart (30 seconds) - restart (30 seconds) - ...
We will go back to ```(start *)``` if the service was up and running for >= ```40 seconds```.

This will aid debugging and cause less spam in logs.

Small nit also add a line ending.

Signed-off-by: Alin Gabriel Serdean <aserdean@ovn.org>