### PR TITLE
Moved the creation of customnat before dcos-net service

### DIFF
--- a/scripts/DCOSWindowsAgentSetup.ps1
+++ b/scripts/DCOSWindowsAgentSetup.ps1
@@ -342,6 +342,7 @@ function New-DCOSServiceWrapper {
 try {
     New-ScriptsDirectory
     Configure-Docker
+    New-DockerNATNetwork
     New-DCOSEnvironmentFile
     New-DCOSMastersListFile
     New-DCOSServiceWrapper
@@ -366,7 +367,6 @@ try {
     # To get collect a complete list of services for node health monitoring,
     # the Diagnostics needs always to be the last one to install
     Install-DiagnosticsAgent -IncludeMatricsService $IsMatricsServiceInstalled
-    New-DockerNATNetwork
     Generate-MesosHttpHealthCheckImage
 } catch {
     Write-Output $_.ToString()


### PR DESCRIPTION
This is to make sure the  customnat creation  is before the DCOS-NET to avoid unreliable DNS service on the agent node we have observed on RS4.