### PR TITLE
Removed  the handler_limit from DCOS-net service sys.config file

### DIFF
--- a/scripts/templates/dcos-net/sys.config
+++ b/scripts/templates/dcos-net/sys.config
@@ -4,7 +4,6 @@
   ]},
 
   {dcos_dns, [
-    {handler_limit, 16},
     {mesos_resolvers, []},
     {upstream_resolvers, {{ upstream_resolvers }}},
     {exhibitor_url, "{{ exhibitor_url }}"},


### PR DESCRIPTION
In the Windows's DCOS-NET implementation, handler_limit was set to 16. This caused DNS on the Windows agent node not to function reliable (some time stop working) on a agent node that has 16+ cpu (such as Standard_D32_V3 Azure Vm size)

Here is how it happened

DCOS-Net leverages a sidejob library for the load-balancing its DNS work load:
In
https://github.com/dcos/dcos-net/blob/1dde472118cc0c52374376bce7729d9107796456/apps/dcos_dns/src/dcos_dns_sup.erl#L41


https://github.com/basho/sidejob/blob/463a4d7b367536a9d29c3c17e63656914107a93a/src/sidejob.erl#L54


https://github.com/basho/sidejob/blob/463a4d7b367536a9d29c3c17e63656914107a93a/src/sidejob.erl#L41


there is a calculation on the number of task could be queued or scheduled to a work thread
WorkerLimit = Limit div Workers,
where: Workers is the number of the workers and its default to the number of scheduler threads (in the case of Standard_D32_V3, it's 32)
Limit is the handler_limit passed from sys.config if it's provided, otherwise it's default to 1024 (Linux agent didn't config this thus get 1024)

We have handler_limit set to 16 in the Windows agent node:
  {dcos_dns, [
    {handler_limit, 16},
    {mesos_resolvers, []},
...
  ]},
====> As long as Workers > Limit, WorkLimit will be 0, which causes no DNS work will be done.
In our, we have 32 CPUs and handler_limit was default to 16
WorkerLimit(0) = Limit(16) div Workers (32).

This is indeed a bug in the DCOS-NET. It should avoid calling new_resource(Name, Mod, Limit, Workers) with Workers>Limit. However, we could mitigate it for the DC/OS cluster by opt -ing to the default value (1024) via removing handler_limit from the Windows' sys.config file 
