### PR TITLE
Clean-up sys.config template

### DIFF
--- a/scripts/dcos-net-agent-setup.ps1
+++ b/scripts/dcos-net-agent-setup.ps1
@@ -135,6 +135,7 @@ function New-DCOSNetWindowsAgent {
         "lashup_dir" = ("${DCOS_NET_DIR}\lashup" -replace '\\', '\\')
         "mnesia_dir" = ("${DCOS_NET_DIR}\mnesia" -replace '\\', '\\')
         "config_dir" = ("${DCOS_NET_DIR}\config.d" -replace '\\', '\\')
+        "dcos_root_dir" = ("${DCOS_NET_DIR}" -replace '\\', '\\')
     }
     $configFile = Join-Path $DCOS_NET_DIR "sys.config"
     Start-RenderTemplate -TemplateFile "$TEMPLATES_DIR\dcos-net\sys.config" `

--- a/scripts/templates/dcos-net/sys.config
+++ b/scripts/templates/dcos-net/sys.config
@@ -12,16 +12,7 @@
     {bind_ips, [{192, 51, 100, 1}, {192, 51, 100, 2}, {192, 51, 100, 3}]}
   ]},
 
-  {erldns,[
-    {storage, [
-      {type, erldns_storage_json},
-      {dir, "db"},
-      {dbname, undefined},
-      {user, undefined},
-      {pass, undefined},
-      {host, undefined},
-      {port, undefined}
-    ]},
+  {erldns, [
     {servers, [[
       {name, inet_localhost_1},
       {address, "127.0.0.1"},
@@ -32,39 +23,25 @@
     {use_root_hints, false},
     {catch_exceptions, false},
     {zones, "{{ dns_zones_file }}"},
-    {metrics, [
-      {port, 61082}
-    ]},
-    {admin, [
-      {port, 61083},
-      {credentials, {"username", "password"}}
-    ]},
-    {pools, [
-      {tcp_worker_pool, erldns_worker, [
-        {size, 10},
-        {max_overflow, 20}
-      ]}
-    ]}
+    {pools, []}
   ]},
 
-  {lashup,
-    [
-      {work_dir, "{{ lashup_dir }}"}
-    ]
-  },
+  {lashup, [
+    {work_dir, "{{ lashup_dir }}"}
+  ]},
 
-  {mnesia,
-    [
-      {dir, "{{ mnesia_dir }}"},
-      {dump_log_write_threshold, 10}
-    ]
-  },
+  {mnesia, [
+    {dir, "{{ mnesia_dir }}"},
+    {dump_log_write_threshold, 10}
+  ]},
 
-  {telemetry,
-    [
-      {forward_metrics, false}
-    ]
-  },
+  {telemetry, [
+    {is_aggregator, false},
+    {forward_metrics, false},
+    {receive_metrics, false},
+    {interval_seconds, 60},
+    {splay_seconds, 20}
+  ]},
 
   {kernel, [
     {start_pg2, true},
@@ -72,14 +49,16 @@
   ]},
 
   {lager, [
-    {log_root, "log"},
+    {error_logger_hwm, 1000},
+    {async_threshold, 1000},
+    {log_root, "{{ dcos_root_dir }}"},
     {handlers, [
       {lager_console_backend, [
-        {level, error}
+        {level, notice}
       ]},
       {lager_file_backend, [
-        {file, "error.log"},
-        {level, error},
+        {file, "log\\error.log"},
+        {level, notice},
         {formatter, lager_default_formatter},
         {formatter_config, [
           date, " ",
@@ -96,5 +75,13 @@
         ]}
       ]}
     ]}
+  ]},
+
+  {sasl, [
+    {sasl_error_logger, {file, "{{ dcos_root_dir }}\\log\\sasl.log"}},
+    {errlog_type, error},
+    {error_logger_mf_dir, "{{ dcos_root_dir }}\\log\\sasl"},      % Log directory
+    {error_logger_mf_maxbytes, 10485760},                         % 10 MB max file size
+    {error_logger_mf_maxfiles, 5}                                 % 5 files max
   ]}
 ].


### PR DESCRIPTION
* Fix lager log_root and log file
* Add sasl logging module
* Make space-formatting consistent with the rest of the file
* Remove erldns configs and make it consistent with what is given
  into the Linux sys.config
* Add telemetry options present in the Linux sys.config. We
  still leave forward_metrics disable as it requires dcos_l4lb.

Co-authored-by: Alin Gabriel Serdean aserdean@ovn.org