### PR TITLE
Add executor registration timeout to the mesos agent on Windows

### DIFF
--- a/scripts/mesos-agent-setup.ps1
+++ b/scripts/mesos-agent-setup.ps1
@@ -83,6 +83,7 @@ function New-MesosWindowsAgent {
                            " --isolation=`"windows/cpu,filesystem/windows`"" + `
                            " --containerizers=`"docker,mesos`"" + `
                            " --attributes=`"${mesosAttributes}`"" + `
+                           " --executor_registration_timeout=$MESOS_REGISTER_TIMEOUT" + `
                            " --hostname=`"${AgentPrivateIP}`"" +
                            " --executor_environment_variables=`"{\\\`"PATH\\\`": \\\`"${mesosPath}\\\`"}`"")
     if($Public) {

--- a/scripts/variables.ps1
+++ b/scripts/variables.ps1
@@ -23,6 +23,10 @@ $MESOS_BIN_DIR = Join-Path $MESOS_DIR "bin"
 $MESOS_WORK_DIR = Join-Path $MESOS_DIR "work"
 $MESOS_LOG_DIR = Join-Path $MESOS_DIR "log"
 $MESOS_SERVICE_DIR = Join-Path $MESOS_DIR "service"
+# From documentation:
+# Amount of time to wait for an executor to register with the slave
+# before considering it hung and shutting it down (e.g., 60secs, 3mins, etc)
+$MESOS_REGISTER_TIMEOUT = "15mins"
 
 # EPMD configurations
 $EPMD_SERVICE_NAME = "dcos-epmd"


### PR DESCRIPTION
Windows docker images have a great footprint and will take some time until
they are pulled to the local image registry.

Mesos agent has a default 1 min timeout for the registration, unfortunately
this is not enough for the size of the images.

Bump the timeout so the tasks won't be removed if they are in pulling state.

Signed-off-by: Alin Gabriel Serdean <aserdean@ovn.org>