### PR TITLE
Set DNS server only on dcos-net interface

### DIFF
--- a/scripts/dcos-net-agent-setup.ps1
+++ b/scripts/dcos-net-agent-setup.ps1
@@ -165,7 +165,13 @@ function New-DCOSNetWindowsAgent {
     New-DCOSWindowsService -Name $DCOS_NET_SERVICE_NAME -DisplayName $DCOS_NET_SERVICE_DISPLAY_NAME -Description $DCOS_NET_SERVICE_DESCRIPTION `
                            -LogFile $logFile -WrapperPath $SERVICE_WRAPPER -EnvironmentFiles @($environmentFile) -BinaryPath "`"$erlBinary $dcosNetArguments`""
     Start-Service $DCOS_NET_SERVICE_NAME
-    Set-DnsClientServerAddress -InterfaceAlias * -ServerAddresses $DCOS_NET_LOCAL_ADDRESSES
+
+    # Set new DNS server address only on dcos-net interface
+    $dcosNetDevice = Get-NetAdapter -Name $DCOS_NET_DEVICE_NAME -ErrorAction SilentlyContinue
+    if(!$dcosNetDevice) {
+        Throw "dcos-net network device was not found"
+    }
+    Set-DnsClientServerAddress -InterfaceAlias "$DCOS_NET_DEVICE_NAME" -ServerAddresses $DCOS_NET_LOCAL_ADDRESSES
 }
 
 


### PR DESCRIPTION
Until now we were setting the dcos-net DNS server on all interfaces.
We should leave the host interface with its former DNS address.

Signed-off-by: Alin Gabriel Serdean <aserdean@ovn.org>
CC: @ionutbalutoiu 