### PR TITLE
Add windows/mem isolator

### DIFF
--- a/scripts/mesos-agent-setup.ps1
+++ b/scripts/mesos-agent-setup.ps1
@@ -80,7 +80,7 @@ function New-MesosWindowsAgent {
                            " --launcher_dir=`"${MESOS_BIN_DIR}`"" + `
                            " --external_log_file=`"${logFile}`"" + `
                            " --ip=`"${agentAddress}`"" + `
-                           " --isolation=`"windows/cpu,filesystem/windows`"" + `
+                           " --isolation=`"windows/cpu,windows/mem,filesystem/windows`"" + `
                            " --containerizers=`"docker,mesos`"" + `
                            " --attributes=`"${mesosAttributes}`"" + `
                            " --hostname=`"${AgentPrivateIP}`"" +


### PR DESCRIPTION
This isolator is used in tandem with windows/cpu for the Mesos
containerizer to correcly enforce memory (and CPU) limits for
non-Docker tasks via job objects.