### PR TITLE
Revert upstream DNS resolver on host interface

### DIFF
--- a/scripts/dcos-net-agent-setup.ps1
+++ b/scripts/dcos-net-agent-setup.ps1
@@ -156,7 +156,6 @@ function New-DCOSNetWindowsAgent {
                            -LogFile $logFile -WrapperPath $SERVICE_WRAPPER -EnvironmentFiles @($environmentFile) -BinaryPath "`"$erlBinary $dcosNetArguments`""
     Start-Service $DCOS_NET_SERVICE_NAME
     Set-DnsClientServerAddress -InterfaceAlias * -ServerAddresses $DCOS_NET_LOCAL_ADDRESSES
-    Set-DnsClientServerAddress -InterfaceIndex (Get-UpstreamInterfaceIndex) -ServerAddresses ($DCOS_NET_LOCAL_ADDRESSES + $upstreamDNS)
 }
 
 


### PR DESCRIPTION
Unfortunately the host DNS resolvers get passed to the docker containers.
This patch goes back to setting the dcos-net resolvers on every interface.

Signed-off-by: Alin Gabriel Serdean <aserdean@ovn.org>