### PR TITLE
Add more logging when file removal fails

### DIFF
--- a/scripts/DCOSWindowsAgentSetup.ps1
+++ b/scripts/DCOSWindowsAgentSetup.ps1
@@ -373,6 +373,8 @@ function Fetch-AgentBlobFiles {
     Write-Log "Extracting the agent blob @ $blobPath to $AGENT_BLOB_ROOT_DIR"
     Measure-Command { Expand-7ZIPFile -File $blobPath -DestinationPath $AGENT_BLOB_ROOT_DIR }
     Remove-Item $blobPath -ErrorAction SilentlyContinue
+    # Add extracted root directory to the current PATH. This is useful for calling utility binaries (i.e. logging)
+    $env:PATH += ";${AGENT_BLOB_ROOT_DIR}"
     Write-Log "Exit Fetch-AgentBlobFiles"
 }
 

--- a/scripts/Modules/Utils/Utils.psm1
+++ b/scripts/Modules/Utils/Utils.psm1
@@ -262,6 +262,10 @@ function Remove-File {
         }
         Write-Log "WARNING: $($_.ToString())"
         Write-Log "WARNING: Failed to remove file: $Path"
+        # This is a non-fatal command. It is used just for logging purposes
+        Write-Log "WARNING: Trying to fetch data on who is blocking the file removal"
+        handles.exe $Path
+        Write-Log "================================================================="
     }
 }
 


### PR DESCRIPTION
This patch uses handles, a binary that shows the list of processes who
keeps a file opened, to add more logging when the utility command `Remove-File`
can not remove files.

We assume that the file `handes.exe` is in the blob storage.

Signed-off-by: Alin Gabriel Serdean <aserdean@ovn.org>