### PR TITLE
Added retries to the docker binaries copy call

### DIFF
--- a/scripts/DCOSWindowsAgentSetup.ps1
+++ b/scripts/DCOSWindowsAgentSetup.ps1
@@ -216,8 +216,8 @@ function Configure-Docker{
     Set-Content -Path "${DOCKER_DATA}\config\daemon.json" -Value '{ "bridge" : "none" }' -Encoding Ascii
 
     # update Docker binaries
-    Copy-item "$AGENT_BLOB_DEST_DIR\docker.exe" "${DOCKER_HOME}\docker.exe" -Force
-    Copy-item "$AGENT_BLOB_DEST_DIR\dockerd.exe" "${DOCKER_HOME}\dockerd.exe" -Force
+    Start-ExecuteWithRetry { Copy-item "$AGENT_BLOB_DEST_DIR\docker.exe" "${DOCKER_HOME}\docker.exe" -Force }
+    Start-ExecuteWithRetry { Copy-item "$AGENT_BLOB_DEST_DIR\dockerd.exe" "${DOCKER_HOME}\dockerd.exe" -Force }
 
     $dockerServiceObj = Start-Service $DOCKER_SERVICE_NAME -PassThru
     $dockerServiceObj.WaitForStatus('Running','00:03:00')


### PR DESCRIPTION
The change in this PR is to address the DC/OS Windows agent deployment failure by attempting retries when it failed for workaround this file-in-use racing condition:

Error in setting up DCOS Windows Agent: The process cannot access the file 'C:\Program Files\Docker\dockerd.exe' because it is being used by another process.

https://github.com/dcos/dcos-windows/issues/101

