### PR TITLE
systemctl-win: Fix compiler warning in ServiceBase.cpp

### DIFF
--- a/systemctl-win/exec/ServiceBase.cpp
+++ b/systemctl-win/exec/ServiceBase.cpp
@@ -69,6 +69,7 @@ BOOL CServiceBase::Run(CServiceBase &service)
     // stopped. The process should simply terminate when the call returns.
     if (bDebug) {
         ServiceMain(0, NULL);
+        return TRUE;
     }
     else {
         return StartServiceCtrlDispatcher(serviceTable);


### PR DESCRIPTION
MSVC complains:
systemctl-win\exec\servicebase.cpp(77): warning C4715: 'CServiceBase::Run': not all control paths return a value

In the case it is in debug mode (the control path that doesn't return a value)
return true.

Signed-off-by: Alin Gabriel Serdean <aserdean@ovn.org>