### PR TITLE
Remove DCOS_BOOTSTRAP_URL environment variable

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -38,7 +38,6 @@ try {
                                               usernameVariable: 'DOCKER_HUB_USER')]) {
                 withEnv(["DCOS_DEPLOYMENT_TYPE=hybrid",
                          "DCOS_WINDOWS_BOOTSTRAP_URL=http://dcos-win.westus.cloudapp.azure.com/dcos-windows/testing/windows-agent-blob/dcos-windows-pr-${GITHUB_PR_NUMBER}-${GITHUB_PR_HEAD_SHA}",
-                         "DCOS_BOOTSTRAP_URL=http://dcos-win.westus.cloudapp.azure.com/dcos/builds/latest/dcos_generate_config.sh",
                          "MASTER_WHITELISTED_IPS=13.66.169.239 13.66.171.181 13.66.173.101 13.66.215.214 13.77.172.69",
                          "AUTOCLEAN=true",
                          "SET_CLEANUP_TAG=true",


### PR DESCRIPTION
The URL that we use is no longer valid. 

We remove the `DCOS_BOOTSTRAP_URL` environment variable and rely on the default value set [here](https://github.com/Microsoft/mesos-jenkins/blob/master/DCOS/dcos-engine-deploy.sh#L32-L34).