### PR TITLE
Fix WaitForStatus method usage

### DIFF
--- a/scripts/agent-setup.ps1
+++ b/scripts/agent-setup.ps1
@@ -113,8 +113,9 @@ function Start-DockerConfiguration {
     Write-Log "Enter Start-DockerConfiguration"
 
     # stop Docker Windows service
+    $timeout = New-TimeSpan -Minutes $SERVICES_WAIT_TIMEOUT
     $dockerServiceObj = Stop-Service $DOCKER_SERVICE_NAME -PassThru
-    $dockerServiceObj.WaitForStatus('Stopped','00:03:00')
+    $dockerServiceObj.WaitForStatus('Stopped', $timeout)
     if ($dockerServiceObj.Status -ne 'Stopped') { 
        Throw "Docker service failed to stop"
     } else {
@@ -131,7 +132,7 @@ function Start-DockerConfiguration {
 
     # start Docker Windows Service
     $dockerServiceObj = Start-Service $DOCKER_SERVICE_NAME -PassThru
-    $dockerServiceObj.WaitForStatus('Running','00:03:00')
+    $dockerServiceObj.WaitForStatus('Running', $timeout)
     if ($dockerServiceObj.Status -ne 'Running') { 
         Throw "Docker service failed to start"
     } else {

--- a/scripts/variables.ps1
+++ b/scripts/variables.ps1
@@ -12,6 +12,9 @@ $SERVICE_WRAPPER = Join-Path $DCOS_DIR $SERVICE_WRAPPER_FILE
 $GLOBAL_ENV_FILE = Join-Path $DCOS_DIR "environment"
 $MASTERS_LIST_FILE = Join-Path $DCOS_DIR "master_list"
 $DCOS_NAT_NETWORK_NAME = "dcosnat"
+# Minutes to wait until Windows services reach the desired status
+# of running / stopped
+$SERVICES_WAIT_TIMEOUT = 3
 
 # Mesos configurations
 $MESOS_SERVICE_NAME = "dcos-mesos-slave"


### PR DESCRIPTION
The second parameter to the `WaitForStatus` method  is a timespan object representing the timeout for waiting the service to be started / stopped.

Passing the string `00:03:00` was not instantiating the desired object representing a timeout of 3 minutes. This pull request fixes this by explicitly creating the timespan object via the `New-TimeSpan` PowerShell cmdlet.