### PR TITLE
Fix erts directory path used & update vm.args template

### DIFF
--- a/scripts/Templates/dcos-net/vm.args
+++ b/scripts/Templates/dcos-net/vm.args
@@ -1,12 +1,12 @@
 -name navstar@{{ agent_private_ip }}
 -setcookie minuteman
 -env ERL_MAX_PORTS 16384
-+A 10
-+K true
 +P 256000
 +C multi_time_warp
 +c true
 -connect_all false
 +t 4194304
 -stbt nnts
-+SDio 0
++SDio 4
+
+# This file MUST have extra new lines at the end

--- a/scripts/dcos-net-agent-setup.ps1
+++ b/scripts/dcos-net-agent-setup.ps1
@@ -57,7 +57,7 @@ function New-Environment {
     New-Directory -RemoveExisting "$DCOS_NET_DIR\lashup"
     New-Directory -RemoveExisting "$DCOS_NET_DIR\mnesia"
     New-Directory -RemoveExisting "$DCOS_NET_DIR\config.d"
-    $binDir = "${DCOS_NET_DIR}\erts-9.2\bin" -replace '\\', '\\'
+    $binDir = "${DCOS_NET_DIR}\erts-10.0.1\bin" -replace '\\', '\\'
     $rootDir = "${DCOS_NET_DIR}" -replace '\\', '\\'
     $context = @{
         'bin_dir' = $binDir
@@ -126,7 +126,7 @@ function Get-UpstreamDNSResolvers {
 }
 
 function New-DCOSNetWindowsAgent {
-    $erlBinary = Join-Path $DCOS_NET_DIR "erts-9.2\bin\erl.exe"
+    $erlBinary = Join-Path $DCOS_NET_DIR "erts-10.0.1\bin\erl.exe"
     if(!(Test-Path $erlBinary)) {
         Throw "The erl binary $erlBinary doesn't exist. Cannot configure the dcos-net Windows agent"
     }


### PR DESCRIPTION
After Erlang got bumped (https://github.com/Microsoft/mesos-jenkins/pull/240) for the Windows build servers, a new version of erts directory is present in the `dcos-net` release package.