### PR TITLE
Conditions specified in service units are not fatal

### DIFF
--- a/systemctl-win/exec/service_exec.cpp
+++ b/systemctl-win/exec/service_exec.cpp
@@ -1069,7 +1069,7 @@ DWORD WINAPI CWrapperService::ServiceThread(LPVOID param)
             *logfile << Info() << L"start " << self->m_ServiceName << "service thread" << std::endl;
             if (!self->EvaluateConditions()) {
                 self->SetServiceStatus(SERVICE_STOPPED);
-                throw RestartException(1, "condition failed");
+                throw RestartException(0, "condition failed");
             }
 
             // If files before exist, bail.


### PR DESCRIPTION
The function `EvaluateConditions` verify if the service should start.

We returned an error if the conditions were not met, this patch fixes that.

Signed-off-by: Alin Gabriel Serdean <aserdean@ovn.org>